### PR TITLE
Fix bound-and-true-p arg with unquote

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -840,7 +840,7 @@ Completion performed by `completion-at-point' or
 arglist for the most recently enclosed macro or function."
   (interactive "P")
   (let ((pos (point))
-        (fn (if (bound-and-true-p 'company-mode)
+        (fn (if (bound-and-true-p company-mode)
                 'company-complete
               'completion-at-point)))
     (indent-for-tab-command arg)


### PR DESCRIPTION
From the description:
```
bound-and-true-p is a Lisp macro in ‘bindings.el’.

(bound-and-true-p VAR)

Return the value of symbol VAR if it is bound, else nil.
```